### PR TITLE
Corrección de errores del Sprint 1

### DIFF
--- a/src/AppForSEII2526.API/Models/Device.cs
+++ b/src/AppForSEII2526.API/Models/Device.cs
@@ -33,7 +33,6 @@ namespace AppForSEII2526.API.Models
 			Year = year;
 		}
 
-		[Key]
 		public int Id { get; set; }
 
 		[Required]
@@ -52,13 +51,13 @@ namespace AppForSEII2526.API.Models
 		public string Color { get; set; }
 
 		[DataType(System.ComponentModel.DataAnnotations.DataType.Currency)]
-        [Range(0.5, float.MaxValue, ErrorMessage = "Minimum price is 0.5")]
+        [Range(0.5, double.MaxValue, ErrorMessage = "Minimum price is 0.5")]
         [Display(Name = "Price For Purchase")]
 		[Required]
         public double PriceForPurchase { get; set; }
 
         [DataType(System.ComponentModel.DataAnnotations.DataType.Currency)]
-		[Range(0.5, float.MaxValue, ErrorMessage = "Minimum price is 0.5")]
+		[Range(0.5, double.MaxValue, ErrorMessage = "Minimum price is 0.5")]
 		[Display(Name = "Price For Renting")]
 		[Required]
 		public double PriceForRent { get; set; }

--- a/src/AppForSEII2526.API/Models/Model.cs
+++ b/src/AppForSEII2526.API/Models/Model.cs
@@ -20,7 +20,6 @@ namespace AppForSEII2526.API.Models
             NameModel = nameModel;
         }
 
-        [Key]
         public int Id { get; set; }
 
         [StringLength(50, ErrorMessage = "Model name cannot be longer than 50 characters.")]

--- a/src/AppForSEII2526.API/Models/Purchase.cs
+++ b/src/AppForSEII2526.API/Models/Purchase.cs
@@ -26,7 +26,6 @@ namespace AppForSEII2526.API.Models
 			PurchaseItems = purchaseItems;
 		}
 
-		[Key]
 		public int Id { get; set; }
 
 		[Required]
@@ -45,7 +44,7 @@ namespace AppForSEII2526.API.Models
 		public DateTime PurchaseDate { get; set; }
 
         [DataType(System.ComponentModel.DataAnnotations.DataType.Currency)]
-        [Range(0.5, float.MaxValue, ErrorMessage = "Minimum price is 0.5")]
+        [Range(0.5, double.MaxValue, ErrorMessage = "Minimum price is 0.5")]
         [Required]
 		public double TotalPrice { get; set; }
 

--- a/src/AppForSEII2526.API/Models/PurchaseItem.cs
+++ b/src/AppForSEII2526.API/Models/PurchaseItem.cs
@@ -37,7 +37,7 @@ namespace AppForSEII2526.API.Models
 		public int DeviceId { get; set; }
 
         [DataType(System.ComponentModel.DataAnnotations.DataType.Currency)]
-        [Range(0.5, float.MaxValue, ErrorMessage = "Minimum price is 0.5")]
+        [Range(0.5, double.MaxValue, ErrorMessage = "Minimum price is 0.5")]
 		[Required]
         public double Price { get; set; }
 

--- a/src/AppForSEII2526.API/Models/Rental.cs
+++ b/src/AppForSEII2526.API/Models/Rental.cs
@@ -30,7 +30,6 @@
         [StringLength(100, ErrorMessage = "El campo DeliveryAddress no puede ser mayor a 100 caracteres ni menor de 1 caracter.", MinimumLength = 1)]
         public string DeliveryAddress { get; set; }
 
-        [Key]
         public int Id { get; set; }
 
         //[Required]

--- a/src/AppForSEII2526.API/Models/Review.cs
+++ b/src/AppForSEII2526.API/Models/Review.cs
@@ -2,7 +2,6 @@
 {
     public class Review
     {
-        [Key]
         public int ReviewId { get; set; }
 
         [StringLength(100)]

--- a/src/AppForSEII2526.API/Models/ReviewItem.cs
+++ b/src/AppForSEII2526.API/Models/ReviewItem.cs
@@ -5,7 +5,6 @@ namespace AppForSEII2526.API.Models
 {
     public class ReviewItem
     {
-        [Key]
         public int Id { get; set; }
 
         [Required]


### PR DESCRIPTION
Quitar las "[Key]" de los atributos nombrados "id" o que contengan "id" en el nombre del atributo.
Cambiar los tipos de "Range" para que coincidan con los de los atributos.